### PR TITLE
Add conda install files and Binder badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,23 @@ Python workshop development and scratch area.
 Within a suitable Python environment, Python code and notebooks at the top level can easily import and run the utility code.  This is one way to set up such an environment:
 ```
 conda create -f environment.yml
-conda activate workshop-dev
+conda activate navo-workshop
+```
+
+# Updating development versions
+The environment may include some development versions. To update to the latest:
+```
+conda env update --file environment.yml --prune
+```
+
+# Starting Jupyterlab
+From the directory containing the notebooks:
+```
+jupyter lab
 ```
 
 # Demo in Binder
 This badge opens Jupyterlab session on Binder which can be used to run the workshop notebooks.
 Note that the session will disapper after being left unattended for several minutes.
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stargaser/workshop-dev/enable-mybinder?urlpath=lab)
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/NASA-NAVO/workshop-dev/master?urlpath=lab)

--- a/README.md
+++ b/README.md
@@ -3,14 +3,11 @@ Python workshop development and scratch area.
 # Setup
 Within a suitable Python environment, Python code and notebooks at the top level can easily import and run the utility code.  This is one way to set up such an environment:
 ```
-conda create --name workshop-dev -c conda-forge python=3.6 astropy matplotlib requests notebook astroquery scipy aplpy 
+conda create -f environment.yml
 conda activate workshop-dev
-
-Currently using development version of pyvo, so:
-
-git clone https://github.com/astropy/pyvo.git
-cd pyvo
-python setup.py develop
-
-(which allows you to 'git pull' as pyvo develops).
 ```
+
+# Demo in Binder
+This badge opens Jupyterlab session on Binder which can be used to run the workshop notebooks.
+Note that the session will disapper after being left unattended for several minutes.
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stargaser/workshop-dev/enable-mybinder?urlpath=lab)

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,6 @@ dependencies:
   - aplpy
   - pip
   - pip:
-    - astroquery
-    - pyvo
-    - navo
+    - git+git://github.com/astropy/astroquery.git
+    - git+git://github.com/astropy/pyvo.git
+    - git+git://github.com/NASA-NAVO/navo.git

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,17 @@
+name: navo-workshop
+channels:
+  - conda-forge
+dependencies:
+  - python=3.6
+  - numpy=1.16.*
+  - astropy=3.2.*
+  - matplotlib
+  - requests
+  - jupyterlab=1.2.*
+  - scipy
+  - aplpy
+  - pip
+  - pip:
+    - astroquery
+    - pyvo
+    - navo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-matplotlib
-numpy
-pyvo
-astropy
-astroquery


### PR DESCRIPTION
Set up for Binder to work with a conda installation of the workshop environment.

* add `environment.yml` to make a `navo-workshop` environment
* pip-install development versions of pyvo, astroquery and navo -- though we will want to pin these for the final workshop repository
* remove `requirements.txt` which is pip-only
* update the README to show how to use `environment.yml` and to add the Binder badge

The URL in the README works now with the current master branch and requirements.txt as added by @trjaffe . To test the feature branch, use [this Binder link](https://mybinder.org/v2/gh/stargaser/workshop-dev/enable-mybinder?urlpath=lab).